### PR TITLE
refactor: storing states in url as search params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "next": "^14.2.13",
         "next-themes": "^0.3.0",
         "nextjs-toploader": "^3.6.15",
+        "nuqs": "^1.19.3",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "recharts": "^2.12.7",
@@ -8842,6 +8843,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
@@ -9104,6 +9111,18 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
+    },
+    "node_modules/nuqs": {
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-1.19.3.tgz",
+      "integrity": "sha512-PpHjONraQDmuJzVQvZvCBNNOij5X0w2pGd8O22lSpRSqKIB6oEmwH+w2M3kGk/Gwf3R6XyvXBb2DSkUHYfrtrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mitt": "^3.0.1"
+      },
+      "peerDependencies": {
+        "next": ">=13.4 <14.0.2 || ^14.0.3"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.12",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "next": "^14.2.13",
     "next-themes": "^0.3.0",
     "nextjs-toploader": "^3.6.15",
+    "nuqs": "^1.19.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "recharts": "^2.12.7",

--- a/src/app/dashboard/EOLDependenciesTable.tsx
+++ b/src/app/dashboard/EOLDependenciesTable.tsx
@@ -27,6 +27,7 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { Dependency } from '@/constants/types'
 import { fetchVersionData } from '@/hooks/useFetchVersionData'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 
 interface EolDependency extends Dependency {
   eol: string
@@ -45,8 +46,13 @@ export default function EolDependenciesTable({
 }) {
   const [eolDependencies, setEolDependencies] = useState<EolDependency[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [selectedEnvironment, setSelectedEnvironment] = useState<string>('PROD')
-  const [showLocal, setShowLocal] = useState(false)
+  const [selectedEnvironment, setSelectedEnvironment] = useQueryState('env', {
+    defaultValue: 'PROD',
+  })
+  const [showLocal, setShowLocal] = useQueryState(
+    'local',
+    parseAsBoolean.withDefault(false),
+  )
 
   useEffect(() => {
     async function fetchEolData() {

--- a/src/app/projects/ProjectList.tsx
+++ b/src/app/projects/ProjectList.tsx
@@ -1,17 +1,20 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useMemo } from 'react'
 import Link from 'next/link'
 import { Input } from '@/components/ui/input'
 import { Card, CardHeader, CardTitle } from '@/components/ui/card'
 import { ExternalLink } from 'lucide-react'
+import { useQueryState } from 'nuqs'
 
 interface ProjectListProps {
   projects: string[]
 }
 
 export default function ProjectList({ projects }: ProjectListProps) {
-  const [searchTerm, setSearchTerm] = useState('')
+  const [searchTerm, setSearchTerm] = useQueryState('search', {
+    defaultValue: '',
+  })
 
   const filteredProjects = useMemo(() => {
     return projects.filter((project) =>

--- a/src/app/versions/TechnologyList.tsx
+++ b/src/app/versions/TechnologyList.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useMemo } from 'react'
 import Link from 'next/link'
 import { Input } from '@/components/ui/input'
 import { Card, CardHeader, CardTitle } from '@/components/ui/card'
 import { ExternalLink } from 'lucide-react'
+import { useQueryState } from 'nuqs'
 
 interface Technology {
   name: string
@@ -17,7 +18,9 @@ interface TechnologyListProps {
 }
 
 export default function TechnologyList({ technologies }: TechnologyListProps) {
-  const [searchTerm, setSearchTerm] = useState('')
+  const [searchTerm, setSearchTerm] = useQueryState('search', {
+    defaultValue: '',
+  })
 
   const filteredTechnologies = useMemo(() => {
     return technologies.filter((tech) =>

--- a/src/app/versions/page.tsx
+++ b/src/app/versions/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import TechnologyList from './TechnologyList'
 import { dependency } from '@/constants/dependency-mappings'
 
@@ -8,7 +9,9 @@ export default function VersionsPage() {
 
   return (
     <div className="container mx-auto p-4">
-      <TechnologyList technologies={sortedDependencies} />
+      <Suspense>
+        <TechnologyList technologies={sortedDependencies} />
+      </Suspense>
     </div>
   )
 }

--- a/src/components/project-tools-table.tsx
+++ b/src/components/project-tools-table.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import {
   Table,
   TableBody,
@@ -14,13 +14,16 @@ import { CurrentVersionTooltip } from '@/components/CurrentVersionTooltip'
 import { Dependency } from '@/constants/types'
 import { LatestVersionCell } from './LatestVersionCell'
 import { EndOfLifeCell } from './EndOfLifeCell'
+import { useQueryState } from 'nuqs'
 
 interface ProjectToolsTableProps {
   data: Dependency[]
 }
 
 export function ProjectToolsTable({ data }: ProjectToolsTableProps) {
-  const [searchTerm, setSearchTerm] = React.useState('')
+  const [searchTerm, setSearchTerm] = useQueryState('search', {
+    defaultValue: '',
+  })
 
   const groupedData = useMemo(() => {
     const grouped: { [key: string]: { [env: string]: string } } = {}

--- a/src/components/project-versions-table.tsx
+++ b/src/components/project-versions-table.tsx
@@ -15,6 +15,7 @@ import { Dependency } from '@/constants/types'
 import { LatestVersionCell } from './LatestVersionCell'
 import { EndOfLifeCell } from './EndOfLifeCell'
 import Link from 'next/link'
+import { useQueryState } from 'nuqs'
 
 interface ProjectVersionsTableProps {
   data: Dependency[]
@@ -25,7 +26,9 @@ export function ProjectVersionsTable({
   data,
   tech,
 }: ProjectVersionsTableProps) {
-  const [searchTerm, setSearchTerm] = React.useState('')
+  const [searchTerm, setSearchTerm] = useQueryState('search', {
+    defaultValue: '',
+  })
 
   const groupedData = useMemo(() => {
     const grouped: { [key: string]: { [env: string]: string } } = {}


### PR DESCRIPTION
- installed [nuqs](https://nuqs.47ng.com/)
- moved search state to url as search params
- moved dashboard env and show local state to url as search params
- this move should enable easy bookmarkability of specific queries
